### PR TITLE
Temporily removing the newsletter signup

### DIFF
--- a/src/components/forms/ga-signup/ga360.tsx
+++ b/src/components/forms/ga-signup/ga360.tsx
@@ -213,11 +213,11 @@ const GAform: React.FC = () => {
               label="I agree"
               legend={`I agree to the <a href="/analytics-360/terms-of-service">Terms of Service</a> and have the financial delegation to spend the required amount for this subscription`}
             />
-            <CheckBoxField
+            {/* <CheckBoxField
               id="cbnewsletter"
               label="Yes"
               legend="I would like to receive product updates from the Observatory team"
-            />
+            /> */}
           </AuFieldset>
           <AuFieldset className="fieldset-group">
             <h3>


### PR DESCRIPTION
Temporily removing the newsletter signup from the ga360 signup page due to some unexpected behaviour